### PR TITLE
Add target creation limit

### DIFF
--- a/app/controllers/api/v1/targets_controller.rb
+++ b/app/controllers/api/v1/targets_controller.rb
@@ -7,11 +7,7 @@ module Api
       end
 
       def create
-        if current_user.targets.count < Target::PER_USER_LIMIT
-          @target = current_user.targets.create!(target_params)
-        else
-          render json: { error: I18n.t('api.errors.max_target_limit_reached') }, status: :bad_request
-        end
+        @target = current_user.targets.create!(target_params)
       end
 
       private

--- a/app/controllers/api/v1/targets_controller.rb
+++ b/app/controllers/api/v1/targets_controller.rb
@@ -7,7 +7,11 @@ module Api
       end
 
       def create
-        @target = current_user.targets.create!(target_params)
+        if current_user.targets.count < Target::PER_USER_LIMIT
+          @target = current_user.targets.create!(target_params)
+        else
+          render json: { error: I18n.t('api.errors.max_target_limit_reached') }, status: :bad_request
+        end
       end
 
       private

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -20,6 +20,14 @@ class Target < ApplicationRecord
   belongs_to :topic
   belongs_to :user
   validates :topic, :title, :lat, :lng, :radius, presence: true
+  validate :target_per_user_limit_reached, on: :create
+
   acts_as_mappable lat_column_name: :lat,
                    lng_column_name: :lng
+
+  def target_per_user_limit_reached
+    if user.targets.count >= Target::PER_USER_LIMIT
+      errors[:user] << I18n.t('api.errors.max_target_limit_reached')
+    end
+  end
 end

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -15,6 +15,7 @@
 
 class Target < ApplicationRecord
   MAX_RADIUS = ENV['TARGET_RADIUS_VISIBILITY'].to_f
+  PER_USER_LIMIT = ENV['TARGET_PER_USER_LIMIT'].to_i
 
   belongs_to :topic
   belongs_to :user

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -9,7 +9,9 @@ unless Rails.env.test?
                   AWS_ACCESS_KEY_ID
                   AWS_SECRET_ACCESS_KEY
                   S3_BUCKET_NAME
-                  AWS_BUCKET_REGION]
+                  AWS_BUCKET_REGION
+                  TARGET_RADIUS_VISIBILITY
+                  TARGET_PER_USER_LIMIT]
 end
 
 Figaro.require_keys(variables)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,3 +26,4 @@ en:
       not_found: "Couldn't find the record"
       missing_param: 'A required param is missing'
       invalid_content_type: 'Invalid content type header'
+      max_target_limit_reached: 'Maximum number of targets reached'

--- a/spec/factories/targets.rb
+++ b/spec/factories/targets.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     lng       { Faker::Address.longitude }
     radius    { Faker::Number.decimal(3) }
     topic
+    user
 
     transient do
       origin { { lat: -34.9, lng: -56.2 } }

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -23,5 +23,10 @@ RSpec.describe Target, type: :model do
     it { should validate_presence_of(:lng) }
     it { should validate_presence_of(:radius) }
     it { should validate_presence_of(:topic) }
+    it 'validates the target limit per user' do
+      subject.user.targets = create_list(:target, Target::PER_USER_LIMIT)
+      subject.valid?
+      expect(subject.errors[:user]).to include(I18n.t('api.errors.max_target_limit_reached'))
+    end
   end
 end

--- a/spec/requests/api/v1/targets/create_spec.rb
+++ b/spec/requests/api/v1/targets/create_spec.rb
@@ -55,17 +55,28 @@ describe 'POST api/v1/targets/', type: :request do
       end
     end
 
-    context 'when the topic does not exist' do
-      let(:topic_id) { 0 }
-
-      it 'does not create a target' do
+    shared_examples 'unchanged target list' do
+      it 'does NOT create a target' do
         expect { subject }.not_to change { Target.count }
       end
 
-      it 'does not return a successful response' do
+      it 'does NOT return a successful response' do
         subject
+
         expect(response).to have_http_status(:bad_request)
       end
+    end
+
+    context 'when the topic does not exist' do
+      let(:topic_id) { 0 }
+
+      include_examples 'unchanged target list'
+    end
+
+    context 'when the user has too many targets' do
+      let!(:user) { create(:user, targets: create_list(:target, Target::PER_USER_LIMIT)) }
+
+      include_examples 'unchanged target list'
     end
   end
 end


### PR DESCRIPTION
- Added user limit for targets creation:
  - Added environment variable.
  - Changed create action in controller.
  - Updated tests.

- Others:
  - Added `Target` related variables to figaro required initializer.